### PR TITLE
Set show splash to false

### DIFF
--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -306,7 +306,7 @@ void reshade::runtime::build_font_atlas()
 
 	ImGui::SetCurrentContext(backup_context);
 
-	_show_splash = true;
+	_show_splash = false;
 
 	int width, height;
 	unsigned char *pixels;
@@ -1873,7 +1873,7 @@ void reshade::runtime::draw_gui_home()
 			save_config();
 			load_current_preset();
 
-			_show_splash = true;
+			_show_splash = false;
 			_preset_is_modified = false;
 			_last_preset_switching_time = _last_present_time;
 			_is_in_preset_transition = true;


### PR DESCRIPTION
This PR hides the initial splash screen of ReShade.